### PR TITLE
feat(secrets): add secrets.status capability

### DIFF
--- a/ops/capabilities.yaml
+++ b/ops/capabilities.yaml
@@ -99,6 +99,14 @@ capabilities:
     approval: auto
     outputs: ["stdout"]
 
+
+  secrets.status:
+    description: "Check secrets configuration presence (no values, no network). Fails if not configured."
+    command: "./ops/plugins/secrets/bin/secrets-status"
+    cwd: "$SPINE_REPO"
+    safety: read-only
+    approval: auto
+    outputs: ["stdout"]
   infra.gh_issue:
     description: "Get GitHub issue details"
     command: "gh issue view"

--- a/ops/plugins/secrets/bin/secrets-status
+++ b/ops/plugins/secrets/bin/secrets-status
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# secrets.status — prove secrets plumbing is either configured or STOP
+# - prints NO secret values
+# - performs NO network calls
+# - creates NO files
+set -euo pipefail
+
+SPINE_REPO="${SPINE_REPO:-$HOME/Code/agentic-spine}"
+SR="$SPINE_REPO/docs/governance/SERVICE_REGISTRY.yaml"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "MISSING_DEP: $1"; return 1; }; }
+
+echo "=== secrets.status ==="
+echo "SPINE_REPO: $SPINE_REPO"
+echo
+
+deps_ok=0
+need yq || deps_ok=1
+need jq || deps_ok=1
+need rg || deps_ok=1
+need curl || deps_ok=1
+
+echo "--- deps ---"
+for b in yq jq rg curl; do
+  if command -v "$b" >/dev/null 2>&1; then echo "OK: $b"; else echo "MISSING: $b"; fi
+done
+echo
+
+echo "--- registry ---"
+if [[ -f "$SR" ]]; then
+  echo "OK: SERVICE_REGISTRY.yaml present"
+  # infisical_projects is a strong signal that secrets are "designed in"
+  if yq e '.infisical_projects | length' "$SR" >/dev/null 2>&1; then
+    n="$(yq e '.infisical_projects | length' "$SR" 2>/dev/null || echo 0)"
+    echo "OK: infisical_projects count = ${n}"
+  else
+    echo "WARN: infisical_projects missing/unreadable"
+  fi
+else
+  echo "WARN: SERVICE_REGISTRY.yaml missing"
+fi
+echo
+
+echo "--- config (no values printed) ---"
+is_set() { [[ -n "${!1:-}" ]] && echo "SET: $1" || echo "MISSING: $1"; }
+
+# Expected env contract (operator sets these; agents never print values)
+is_set INFISICAL_API_URL
+is_set INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+is_set INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+
+echo
+echo "--- verdict ---"
+# If deps missing -> hard fail
+if [[ "$deps_ok" -ne 0 ]]; then
+  echo "STATUS: FAIL (missing deps)"
+  exit 1
+fi
+
+# If secret missing -> STOP (fail) so agents cannot proceed into API work
+if [[ -z "${INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET:-}" ]]; then
+  echo "STATUS: STOP (secrets not configured)"
+  echo "ACTION: Operator must provide secrets via env (do not commit)."
+  exit 2
+fi
+
+echo "STATUS: OK (secrets configured)"
+exit 0


### PR DESCRIPTION
## Summary
- Add `secrets.status` capability (read-only, no network, no values printed)
- Returns STOP (exit 2) if secrets not configured
- Agents must run this before any API work

## Behavior
- Checks deps (yq, jq, rg, curl)
- Checks SERVICE_REGISTRY.yaml presence
- Checks env vars (INFISICAL_*) are SET (never prints values)
- Exit 0 = OK, Exit 2 = STOP, Exit 1 = deps issue

## Proof
- Receipt: `RCAP-20260202-220814__secrets.status__R8daw26395` (STOP as expected)
- Gates green: verify, replay, status

🤖 Generated with [Claude Code](https://claude.com/claude-code)