### PR TITLE
feat(secrets): add secrets.projects.status

### DIFF
--- a/ops/capabilities.yaml
+++ b/ops/capabilities.yaml
@@ -143,6 +143,14 @@ capabilities:
     approval: auto
     outputs: ["stdout"]
 
+  secrets.projects.status:
+    description: "Show spine binding + projects catalog excerpt; STOP (exit 2) if bound project not ACTIVE per SSOT map."
+    command: "./ops/plugins/secrets/bin/secrets-projects-status"
+    cwd: "$SPINE_REPO"
+    safety: read-only
+    approval: auto
+    outputs: ["stdout"]
+
   # ─────────────────────────────────────────────────────────────────────────
   # FUTURE: MUTATING (require manual approval)
   # ─────────────────────────────────────────────────────────────────────────

--- a/ops/plugins/secrets/bin/secrets-projects-status
+++ b/ops/plugins/secrets/bin/secrets-projects-status
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# If SPINE_REPO env var is set (by capability runner), use it; otherwise compute
+if [ -n "${SPINE_REPO:-}" ]; then
+  SPINE_ROOT="$SPINE_REPO"
+else
+  # Fallback: compute from script location
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  SPINE_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+fi
+
+BINDING="$SPINE_ROOT/ops/bindings/secrets.binding.yaml"
+MAP="$SPINE_ROOT/docs/core/INFISICAL_PROJECTS.md"
+
+echo "════════════════════════════════════════"
+echo "CAPABILITY: secrets.projects.status"
+echo "════════════════════════════════════════"
+echo
+
+# Preconditions: files exist
+test -f "$BINDING" || { echo "STOP: missing binding file: $BINDING"; exit 2; }
+test -f "$MAP" || { echo "STOP: missing projects map: $MAP"; exit 2; }
+
+# Pull project id/name from binding (extract UUID from quoted YAML value).
+BOUND_ID="$(grep 'project:' "$BINDING" | head -1 | sed -E 's/.*"([a-f0-9-]{36})".*/\1/' || true)"
+BOUND_ENV="$(grep 'environment:' "$BINDING" | head -1 | sed -E 's/.*:[[:space:]]+"?([a-zA-Z0-9_]+)"?.*/\1/' || true)"
+
+if test -z "${BOUND_ID:-}"; then
+  echo "STOP: could not read project from binding: $BINDING"
+  exit 2
+fi
+if test -z "${BOUND_ENV:-}"; then
+  BOUND_ENV="prod"
+fi
+
+echo "Binding:"
+echo "  project_id: $BOUND_ID"
+echo "  environment: $BOUND_ENV"
+echo
+
+# Extract the catalog table and show it (small, deterministic).
+echo "Project catalog (excerpt):"
+awk '
+  BEGIN {in_table=0}
+  /^\|[[:space:]]*lifecycle[[:space:]]*\|/ {in_table=1}
+  in_table {print}
+  in_table && /^[[:space:]]*$/ {exit}
+' "$MAP" | head -50
+
+echo
+
+# Enforce: bound project must be ACTIVE per SSOT map table.
+# The ACTIVE row for infrastructure contains: | **ACTIVE** | **infrastructure** | `01ddd93a...` |
+if grep -q "| \*\*ACTIVE\*\* |.*\`$BOUND_ID\`" "$MAP" 2>/dev/null || \
+   grep -q "| ACTIVE |.*\`$BOUND_ID\`" "$MAP" 2>/dev/null || \
+   grep -q "|.*ACTIVE.*|$BOUND_ID|" "$MAP" 2>/dev/null; then
+  echo "OK: bound project ($BOUND_ID) is ACTIVE in docs/core/INFISICAL_PROJECTS.md"
+  exit 0
+fi
+
+echo "STOP: bound project ($BOUND_ID) is NOT marked ACTIVE in docs/core/INFISICAL_PROJECTS.md"
+echo "Fix: update the lifecycle table or change ops/bindings/secrets.binding.yaml"
+exit 2


### PR DESCRIPTION
Adds read-only capability that prints current Infisical binding + SSOT project catalog excerpt and enforces STOP(2) if the bound project is not marked ACTIVE in docs/core/INFISICAL_PROJECTS.md.

Key behaviors:
- Extracts project ID from ops/bindings/secrets.binding.yaml
- Displays project catalog table with lifecycle status  
- Validates binding against ACTIVE status in SSOT map
- Exits 0 if valid, exits 2 if bound project not ACTIVE

No ronny-ops dependencies; fully self-contained in agentic-spine.