### PR TITLE
feat(spine): add ready check helper

### DIFF
--- a/bin/ops
+++ b/bin/ops
@@ -44,6 +44,9 @@ case "$COMMAND" in
   loops)
     source "$SCRIPT_DIR/../ops/commands/loops.sh" "$@"
     ;;
+  ready)
+    source "$SCRIPT_DIR/../ops/commands/ready.sh" "$@"
+    ;;
   *)
     echo "ops - governance-aware operations helper"
     echo
@@ -55,6 +58,7 @@ case "$COMMAND" in
     echo "  ops preflight        Print governance banner + service registry hints"
     echo "  ops lane <name>      Show lane header (builder|runner|clerk)"
     echo "  ops verify           Health-check services declared in SERVICE_REGISTRY.yaml"
+    echo "  ops ready            Run spine gates + secrets checks (API work preflight)"
     echo "  ops pr [...args]     Stage/commit/push changes and open a PR for issue"
     echo "  ops close [issue]    Run verify, confirm PR merged, update state, close issue"
     echo "  ops ai [--bundle X]  Bundle governance docs for AI agents"

--- a/docs/OPERATOR_CHEAT_SHEET.md
+++ b/docs/OPERATOR_CHEAT_SHEET.md
@@ -1,0 +1,81 @@
+# Operator Cheat Sheet
+
+Quick reference for spine operations and governance tasks.
+
+## Common Operations
+
+### Start work on an issue
+```bash
+cd ~/Code/agentic-spine
+ops start ISSUE_NUMBER
+```
+
+### Verify infrastructure
+```bash
+ops verify
+```
+
+### Run capabilities
+```bash
+ops cap list                          # List all capabilities
+ops cap run <capability_name>          # Run a specific capability
+ops cap show <capability_name>          # Show capability details
+```
+
+### Stage and create PR
+```bash
+ops pr create                          # Stage, commit, push, and create PR
+ops pr close ISSUE_NUMBER               # Verify, confirm merge, close issue
+```
+
+## Ready check (before any API work)
+
+Run in terminal you intend to use for API-touching capabilities:
+
+- `./bin/ops ready`
+
+If it STOPs (exit 2), run the one-liner it prints:
+
+- `source ~/.config/infisical/credentials`
+
+Then rerun `./bin/ops ready`.
+
+### What ready check does
+1. Runs spine health gates (verify, replay, status)
+2. Checks secrets binding
+3. Validates Infisical auth hydration
+4. Checks bound project is ACTIVE per SSOT
+5. Exits 0 if terminal is cleared for API work
+
+### Why this exists
+Shell environments cannot be reliably mutated by subprocess capabilities. The `ops ready` command provides a single operator ritual that validates auth is hydrated before any API-touching capability runs.
+
+## Capability Categories
+
+### Spine Health
+- `spine.verify` - Drift gate health check
+- `spine.replay` - Determinism verification
+- `spine.status` - Watcher and queue status
+
+### Secrets Management
+- `secrets.binding` - Print binding (SSOT)
+- `secrets.auth.load` - Load auth guidance
+- `secrets.auth.status` - Check auth presence
+- `secrets.projects.status` - Verify bound project is ACTIVE
+
+### GitHub Integration
+- `github.actions.status` - Workflow run counts + latest conclusion
+- `github.queue.status` - PR queue state
+
+### Cloudflare Integration
+- `cloudflare.records.status` - DNS record validation
+
+## Governance
+
+All capabilities are governed by:
+- Read-only safety checks
+- Precondition chains (.requires[])
+- Receipt generation for audit trail
+- SSOT binding validation
+
+See `docs/governance/` for full governance documentation.

--- a/ops/commands/ready.sh
+++ b/ops/commands/ready.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+run_cap() {
+  local cap="$1"
+  shift || true
+  echo
+  echo "────────────────────────────────────────"
+  echo "READY CHECK: $cap"
+  echo "────────────────────────────────────────"
+  ./bin/ops cap run "$cap" "$@"
+}
+
+echo "========================================"
+echo "SPINE READY CHECK (operator convenience)"
+echo "========================================"
+
+run_cap spine.verify
+run_cap spine.replay
+run_cap spine.status
+
+run_cap secrets.binding
+run_cap secrets.auth.load
+
+set +e
+run_cap secrets.auth.status
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  :
+elif [[ $rc -eq 2 ]]; then
+  echo
+  echo "STOP (exit 2): Infisical auth is NOT hydrated in this terminal."
+  echo
+  echo "Run this once in *this same terminal*:"
+  echo "  source \"$HOME/.config/infisical/credentials\""
+  echo
+  echo "Then rerun:"
+  echo "  ./bin/ops ready"
+  exit 2
+else
+  echo
+  echo "FAIL: secrets.auth.status exited $rc"
+  exit $rc
+fi
+
+run_cap secrets.projects.status
+
+echo
+echo "READY: This terminal is cleared for API-touching capabilities."


### PR DESCRIPTION
Adds ./bin/ops ready: runs spine gates + secrets checks and STOPs (exit 2) if Infisical auth is not hydrated in current shell. Does not store secrets or mutate shell env; prints one-liner to source ~/.config/infisical/credentials.