### PR TITLE
feat(spine): D18 docker compose drift gate

### DIFF
--- a/surfaces/verify/d18-docker-compose-drift.sh
+++ b/surfaces/verify/d18-docker-compose-drift.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CAP_SCRIPT="$ROOT/ops/plugins/docker/bin/docker-compose-status"
+
+fail(){ echo "D18 FAIL: $*" >&2; exit 1; }
+
+# 1) Capability script must exist + be executable
+[[ -f "$CAP_SCRIPT" ]] || fail "missing $CAP_SCRIPT"
+[[ -x "$CAP_SCRIPT" ]] || fail "not executable: $CAP_SCRIPT"
+
+# 2) No legacy/runtime smell coupling in docker plugin surface
+# (keep this conservative; we only scan the plugin script)
+if rg -n --hidden --no-ignore-vcs -S \
+  '(ronny-ops|~/agent|/agent/|LaunchAgents|launchd|\.plist\b|cron\b|state/|/state/|receipts/|/receipts/)' \
+  "$CAP_SCRIPT" >/dev/null; then
+  fail "legacy/runtime smell markers found in docker-compose-status"
+fi
+
+# 3) Read-only enforcement: forbid mutating docker/compose operations
+# Allow: ps, ls, inspect, config, version
+if rg -n -S \
+  '\bdocker(\s+-[^\n]+)?\s+(compose|stack)\s+(up|down|restart|rm|stop|start|kill|pull|build|create|run|exec)\b' \
+  "$CAP_SCRIPT" >/dev/null; then
+  fail "mutating docker compose/stack command found"
+fi
+
+# Also forbid destructive docker commands
+if rg -n -S '\bdocker\s+(system\s+prune|volume\s+rm|network\s+rm|image\s+rm|container\s+rm)\b' \
+  "$CAP_SCRIPT" >/dev/null; then
+  fail "destructive docker command found"
+fi
+
+# 4) HTTP method guard (should be none here, but keep consistent with other API gates)
+if rg -n -S '\bcurl\b.*\s-X\s*(POST|PUT|PATCH|DELETE)\b' "$CAP_SCRIPT" >/dev/null; then
+  fail "mutating HTTP method found"
+fi
+
+# 5) Token leak guardrail (never print secrets)
+if rg -n -S '(echo|printf).*(TOKEN|SECRET|API_KEY|PASSWORD)|set\s+-x' "$CAP_SCRIPT" >/dev/null; then
+  fail "potential secret printing/debug tracing found"
+fi
+
+echo "D18 PASS: docker.compose.status drift surface locked"

--- a/surfaces/verify/drift-gate.sh
+++ b/surfaces/verify/drift-gate.sh
@@ -49,7 +49,8 @@ COUPLE="$(rg -n '(\$HOME/agent|~/agent)' bin ops ops/runtime/inbox surfaces/veri
   | rg -v 'foundation-gate.sh' \
   | rg -v 'drift-gate.sh' \
   | rg -v 'cloudflare-drift-gate.sh' \
-  | rg -v 'github-actions-gate.sh' || true)"
+  | rg -v 'github-actions-gate.sh' \
+  | rg -v 'd18-docker-compose-drift.sh' || true)"
 [[ -z "$COUPLE" ]] && pass || fail "legacy coupling found"
 
 # D6: Receipts exist (latest 5 have receipt.md)
@@ -198,6 +199,18 @@ if [[ -x "$SP/surfaces/verify/d17-root-allowlist.sh" ]]; then
   fi
 else
   warn "root allowlist gate not present"
+fi
+
+# D18: Docker compose surface drift gate (read-only, no legacy smells)
+echo -n "D18 docker compose drift gate... "
+if [[ -x "$SP/surfaces/verify/d18-docker-compose-drift.sh" ]]; then
+  if "$SP/surfaces/verify/d18-docker-compose-drift.sh" >/dev/null 2>&1; then
+    pass
+  else
+    fail "d18-docker-compose-drift.sh failed"
+  fi
+else
+  warn "docker compose drift gate not present"
 fi
 
 echo


### PR DESCRIPTION
## Summary
- Adds D18 drift gate to lock `docker.compose.status` surface
- Forbids legacy/runtime smell coupling in docker plugin
- Enforces read-only docker compose/stack usage
- Blocks destructive docker commands
- Blocks mutating HTTP methods
- Blocks token printing/debug tracing

## Test plan
- [x] D1-D18 all PASS
- [x] spine.replay deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)