### PR TITLE
feat(backup): add backup.status (file_glob)

### DIFF
--- a/ops/bindings/backup.inventory.yaml
+++ b/ops/bindings/backup.inventory.yaml
@@ -1,0 +1,27 @@
+version: 1
+
+# backup.status inventory is FILE_GLOB only (boring mode).
+# - Non-secret configuration (paths + globs + freshness)
+# - Tied to SSH targets by name (ops/bindings/ssh.targets.yaml)
+# - Targets are disabled by default so we never "green" a fake inventory.
+defaults:
+  timezone: "America/New_York"
+  ssh_timeout_sec: 6
+  stale_after_hours: 26
+
+targets:
+  # EXAMPLE (enable + edit to your real paths):
+  - name: "proxmox-vzdump"
+    enabled: false
+    kind: "file_glob"
+    host: "nas"                     # must exist in ops/bindings/ssh.targets.yaml
+    base_path: "/volume1/backups/proxmox/vzdump"
+    glob: "*.vma.zst"
+    stale_after_hours: 26           # optional override
+
+  - name: "docker-host-snapshots"
+    enabled: false
+    kind: "file_glob"
+    host: "docker-host"
+    base_path: "/srv/backups"
+    glob: "*.tar.zst"

--- a/ops/capabilities.yaml
+++ b/ops/capabilities.yaml
@@ -253,6 +253,20 @@ capabilities:
     approval: auto
     outputs: ["stdout"]
 
+  # ─────────────────────────────────────────────────────────────────────────
+  # BACKUP (read-only inventory status)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  backup.status:
+    description: "Read-only backup inventory status (file_glob only, freshness + reason codes)."
+    command: "./ops/plugins/backup/bin/backup-status"
+    cwd: "$SPINE_REPO"
+    safety: read-only
+    approval: auto
+    # NOTE: No requires - script handles SSH errors per-target with reason codes.
+    # Run ssh.target.status separately if you need pre-flight SSH connectivity check.
+    outputs: ["stdout"]
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Safety Levels
 # ═══════════════════════════════════════════════════════════════════════════

--- a/ops/plugins/backup/bin/backup-status
+++ b/ops/plugins/backup/bin/backup-status
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINDING_FILE="${BINDING_FILE:-ops/bindings/backup.inventory.yaml}"
+SSH_TARGETS_FILE="${SSH_TARGETS_FILE:-ops/bindings/ssh.targets.yaml}"
+
+_need() { command -v "$1" >/dev/null 2>&1 || { echo "STOP: missing dependency: $1" >&2; exit 2; }; }
+
+_need yq
+_need ssh
+_need date
+
+if [[ ! -f "$BINDING_FILE" ]]; then
+  echo "STOP: missing binding file: $BINDING_FILE" >&2
+  exit 2
+fi
+if [[ ! -f "$SSH_TARGETS_FILE" ]]; then
+  echo "STOP: missing ssh targets binding: $SSH_TARGETS_FILE" >&2
+  exit 2
+fi
+
+DEFAULT_STALE="$(yq -r '.defaults.stale_after_hours // 26' "$BINDING_FILE")"
+DEFAULT_SSH_TIMEOUT="$(yq -r '.defaults.ssh_timeout_sec // 6' "$BINDING_FILE")"
+TZ_NAME="$(yq -r '.defaults.timezone // "America/New_York"' "$BINDING_FILE")"
+
+# enabled targets only
+TARGET_LINES="$(
+  yq -r '
+    .targets[]
+    | select((.enabled // false) == true)
+    | select(.kind == "file_glob")
+    | [
+        .name,
+        .host,
+        .base_path,
+        .glob,
+        ((.stale_after_hours // '"$DEFAULT_STALE"')|tostring),
+        ((.ssh_timeout_sec // '"$DEFAULT_SSH_TIMEOUT"')|tostring)
+      ] | @tsv
+  ' "$BINDING_FILE"
+)"
+
+if [[ -z "${TARGET_LINES//[[:space:]]/}" ]]; then
+  echo "STOP: no enabled file_glob targets in $BINDING_FILE"
+  echo "Hint: set enabled: true on at least one target after you fill host/base_path/glob."
+  exit 2
+fi
+
+# Get list of known SSH target names
+KNOWN_TARGETS="$(yq -r '.targets[].name' "$SSH_TARGETS_FILE" 2>/dev/null || true)"
+
+_now_epoch() {
+  date -u +%s
+}
+
+_fmt_iso_local() {
+  # epoch -> ISO-ish local time (best-effort, no hard dependency on gdate)
+  local epoch="$1"
+  TZ="$TZ_NAME" date -r "$epoch" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null || \
+  TZ="$TZ_NAME" date -d "@$epoch" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null || \
+  echo "n/a"
+}
+
+_classify_ssh_error() {
+  local stderr="$1"
+  if echo "$stderr" | grep -qi "permission denied"; then echo "auth_denied"; return; fi
+  if echo "$stderr" | grep -qi "host key verification failed\|remote host identification has changed"; then echo "host_key_mismatch"; return; fi
+  if echo "$stderr" | grep -qi "connection refused"; then echo "connect_refused"; return; fi
+  if echo "$stderr" | grep -qi "operation timed out\|connection timed out\|timed out"; then echo "connect_timeout"; return; fi
+  if echo "$stderr" | grep -qi "could not resolve hostname\|name or service not known"; then echo "ssh_unreachable"; return; fi
+  echo "auth_or_connect"
+}
+
+echo "backup.status"
+echo "binding: $BINDING_FILE"
+echo
+
+# Header
+printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+  "target" "host" "base_path" "newest_file" "newest_mtime" "age_hrs" "status" "reason"
+
+TOTAL=0
+OK=0
+DEGRADED=0
+NOW="$(_now_epoch)"
+
+while IFS=$'\t' read -r NAME HOST BASE_PATH GLOB STALE_HOURS SSH_TIMEOUT; do
+  [[ -z "$NAME" ]] && continue
+  TOTAL=$((TOTAL+1))
+
+  # validate host exists in ssh.targets.yaml names
+  if ! echo "$KNOWN_TARGETS" | grep -qx "$HOST"; then
+    printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+      "$NAME" "$HOST" "${BASE_PATH:0:28}" "-" "-" "-" "ERROR" "unknown_host_binding"
+    DEGRADED=$((DEGRADED+1))
+    continue
+  fi
+
+  # Remote probe script (read-only: test -d, ls, stat only)
+  REMOTE_SCRIPT='
+set -euo pipefail
+BASE="$1"
+GLOB="$2"
+if [ ! -d "$BASE" ]; then echo "DIR_MISSING"; exit 0; fi
+cd "$BASE"
+F="$(ls -1t -- $GLOB 2>/dev/null | head -n 1 || true)"
+if [ -z "$F" ]; then echo "NO_MATCHES"; exit 0; fi
+MTIME="$(stat -c %Y "$F" 2>/dev/null || stat -f %m "$F" 2>/dev/null || echo "")"
+echo "NEWEST=$F"
+echo "MTIME=$MTIME"
+'
+
+  STDERR_FILE="/tmp/backup_status_${NAME}_stderr.$$"
+  set +e
+  OUT="$(
+    ssh \
+      -o BatchMode=yes \
+      -o ConnectTimeout="$SSH_TIMEOUT" \
+      -o StrictHostKeyChecking=accept-new \
+      "$HOST" "bash -c '$REMOTE_SCRIPT' -- $(printf "%q" "$BASE_PATH") $(printf "%q" "$GLOB")" \
+      2>"$STDERR_FILE"
+  )"
+  RC=$?
+  ERR="$(cat "$STDERR_FILE" 2>/dev/null || true)"
+  rm -f "$STDERR_FILE"
+  set -e
+
+  if [[ $RC -ne 0 ]]; then
+    REASON="$(_classify_ssh_error "$ERR")"
+    printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+      "$NAME" "$HOST" "${BASE_PATH:0:28}" "-" "-" "-" "ERROR" "$REASON"
+    DEGRADED=$((DEGRADED+1))
+    continue
+  fi
+
+  if echo "$OUT" | grep -qx "DIR_MISSING"; then
+    printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+      "$NAME" "$HOST" "${BASE_PATH:0:28}" "-" "-" "-" "MISSING" "path_missing"
+    DEGRADED=$((DEGRADED+1))
+    continue
+  fi
+
+  if echo "$OUT" | grep -qx "NO_MATCHES"; then
+    printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+      "$NAME" "$HOST" "${BASE_PATH:0:28}" "-" "-" "-" "MISSING" "no_matches"
+    DEGRADED=$((DEGRADED+1))
+    continue
+  fi
+
+  NEWEST="$(echo "$OUT" | sed -n 's/^NEWEST=//p' | head -n1)"
+  MTIME_EPOCH="$(echo "$OUT" | sed -n 's/^MTIME=//p' | head -n1)"
+
+  if [[ -z "${MTIME_EPOCH:-}" ]] || ! echo "$MTIME_EPOCH" | grep -Eq '^[0-9]+$'; then
+    printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+      "$NAME" "$HOST" "${BASE_PATH:0:28}" "${NEWEST:0:24}" "-" "-" "ERROR" "parse_error"
+    DEGRADED=$((DEGRADED+1))
+    continue
+  fi
+
+  AGE_SEC=$((NOW - MTIME_EPOCH))
+  if [[ $AGE_SEC -lt 0 ]]; then AGE_SEC=0; fi
+  AGE_HRS="$(awk -v s="$AGE_SEC" 'BEGIN{printf "%.1f", s/3600.0}')"
+  MTIME_FMT="$(_fmt_iso_local "$MTIME_EPOCH")"
+
+  STATUS="OK"
+  REASON="ok"
+  # compare as integers for stale threshold
+  AGE_HRS_INT=$((AGE_SEC / 3600))
+  if [[ $AGE_HRS_INT -gt $STALE_HOURS ]]; then
+    STATUS="STALE"
+    REASON="stale"
+    DEGRADED=$((DEGRADED+1))
+  else
+    OK=$((OK+1))
+  fi
+
+  printf "%-22s %-14s %-28s %-24s %-22s %-9s %-8s %s\n" \
+    "$NAME" "$HOST" "${BASE_PATH:0:28}" "${NEWEST:0:24}" "${MTIME_FMT:0:22}" "$AGE_HRS" "$STATUS" "$REASON"
+
+done <<< "$TARGET_LINES"
+
+echo
+echo "summary: $TOTAL targets | $OK ok | $DEGRADED degraded"


### PR DESCRIPTION
## Summary
- Adds spine-native `backup.status` capability (file_glob only, boring mode)
- Binding at `ops/bindings/backup.inventory.yaml` (non-secret, targets disabled by default)
- Per-target SSH error handling with reason codes: `ok`, `stale`, `no_matches`, `path_missing`, `auth_denied`, `connect_timeout`, `unknown_host_binding`, etc.
- No `requires` dependency - handles SSH errors gracefully per-target

## Files
- `ops/bindings/backup.inventory.yaml` - inventory SSOT (disabled by default)
- `ops/plugins/backup/bin/backup-status` - read-only inventory script
- `ops/capabilities.yaml` - capability registration

## Test plan
- [x] D1-D18 all PASS
- [x] spine.replay deterministic
- [x] backup.status exits 2 with no enabled targets (expected)

## Post-merge
Enable real targets in `ops/bindings/backup.inventory.yaml`:
```yaml
- name: "proxmox-vzdump"
  enabled: true  # <-- flip this
  host: "nas"
  base_path: "/volume1/backups/proxmox/vzdump"
  glob: "*.vma.zst"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)