### PR TITLE
feat(backup): seed inventory from ronny-ops SSOT + fix SSH lookup

### DIFF
--- a/ops/bindings/backup.inventory.yaml
+++ b/ops/bindings/backup.inventory.yaml
@@ -1,27 +1,94 @@
+# Seeded from ronny-ops SSOT: infrastructure/data/backup_inventory.json
+# NOTE: enabled=false by default; flip true intentionally per target.
+# Classifications: critical (26h), important (48h), rebuildable (168h)
 version: 1
 
-# backup.status inventory is FILE_GLOB only (boring mode).
-# - Non-secret configuration (paths + globs + freshness)
-# - Tied to SSH targets by name (ops/bindings/ssh.targets.yaml)
-# - Targets are disabled by default so we never "green" a fake inventory.
 defaults:
   timezone: "America/New_York"
   ssh_timeout_sec: 6
   stale_after_hours: 26
 
 targets:
-  # EXAMPLE (enable + edit to your real paths):
-  - name: "proxmox-vzdump"
+  # NOTE: vzdump files not yet synced to NAS (see ronny-ops BACKUP_GOVERNANCE.md)
+  - name: vm-200-docker-host
     enabled: false
-    kind: "file_glob"
-    host: "nas"                     # must exist in ops/bindings/ssh.targets.yaml
+    kind: file_glob
+    host: nas
     base_path: "/volume1/backups/proxmox/vzdump"
-    glob: "*.vma.zst"
-    stale_after_hours: 26           # optional override
+    glob: "vzdump-qemu-200-*.vma.zst"
+    stale_after_hours: 26
+    classification: critical
 
-  - name: "docker-host-snapshots"
+  # NOTE: path doesn't exist yet on NAS
+  - name: app-mint-postgres
     enabled: false
-    kind: "file_glob"
-    host: "docker-host"
-    base_path: "/srv/backups"
-    glob: "*.tar.zst"
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/mint-postgres"
+    glob: "*.sql.gz"
+    stale_after_hours: 26
+    classification: critical
+
+  # NOTE: path doesn't exist yet on NAS
+  - name: app-infisical
+    enabled: false
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/infisical"
+    glob: "*.sql.gz"
+    stale_after_hours: 26
+    classification: critical
+
+  - name: app-vaultwarden
+    enabled: true
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/vaultwarden"
+    glob: "*.tar.gz"
+    stale_after_hours: 26
+    classification: critical
+
+  - name: app-home-assistant
+    enabled: true
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/home-assistant"
+    glob: "*.tar"
+    stale_after_hours: 48
+    classification: important
+
+  - name: app-firefly
+    enabled: false
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/finance"
+    glob: "*.sql.gz"
+    stale_after_hours: 48
+    classification: important
+
+  - name: app-minio
+    enabled: false
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/minio"
+    glob: "*.tar.gz"
+    stale_after_hours: 48
+    classification: important
+
+  - name: device-ronny-macbook
+    enabled: false
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/devices/ronny-macbook"
+    glob: "*"
+    stale_after_hours: 26
+    classification: critical
+
+  - name: asset-dns-domain
+    enabled: false
+    kind: file_glob
+    host: nas
+    base_path: "/volume1/backups/apps/cloudflare"
+    glob: "*"
+    stale_after_hours: 26
+    classification: critical

--- a/ops/plugins/backup/bin/backup-status
+++ b/ops/plugins/backup/bin/backup-status
@@ -46,8 +46,8 @@ if [[ -z "${TARGET_LINES//[[:space:]]/}" ]]; then
   exit 2
 fi
 
-# Get list of known SSH target names
-KNOWN_TARGETS="$(yq -r '.targets[].name' "$SSH_TARGETS_FILE" 2>/dev/null || true)"
+# Get list of known SSH target IDs
+KNOWN_TARGETS="$(yq -r '.ssh.targets[].id' "$SSH_TARGETS_FILE" 2>/dev/null || true)"
 
 _now_epoch() {
   date -u +%s
@@ -113,7 +113,7 @@ echo "MTIME=$MTIME"
   STDERR_FILE="/tmp/backup_status_${NAME}_stderr.$$"
   set +e
   OUT="$(
-    ssh \
+    ssh -n \
       -o BatchMode=yes \
       -o ConnectTimeout="$SSH_TIMEOUT" \
       -o StrictHostKeyChecking=accept-new \


### PR DESCRIPTION
## Summary

- Seed `ops/bindings/backup.inventory.yaml` from ronny-ops SSOT (`infrastructure/data/backup_inventory.json`)
- Fix SSH target lookup in `backup-status` (was using wrong yq path)
- Enable 2 verified targets: `app-vaultwarden`, `app-home-assistant`

## Changes

**backup.inventory.yaml:**
- 9 targets seeded from ronny-ops (2 enabled, 7 disabled pending NAS path setup)
- Added `classification` field per tier (critical 26h, important 48h, rebuildable 168h)
- Disabled targets annotated with notes explaining why (paths don't exist yet)

**backup-status:**
- Fix: Changed `.targets[].name` → `.ssh.targets[].id` to match ssh.targets.yaml schema

## Verification

```
$ ./bin/ops cap run backup.status

target                 host   base_path                    newest_file              newest_mtime           age_hrs   status   reason
app-vaultwarden        nas    /volume1/backups/apps/vaultw vaultwarden-backup-2026- 2026-02-01 02:45:06 ES 62.4      STALE    stale
app-home-assistant     nas    /volume1/backups/apps/home-a e90e7b71.tar             2026-01-12 03:43:11 ES 541.5     STALE    stale

summary: 2 targets | 0 ok | 2 degraded
```

Both targets resolve correctly. STALE status is real (backups genuinely old).

## Test plan

- [x] `./bin/ops cap run backup.status` shows both enabled targets
- [x] SSH lookup resolves `nas` host correctly
- [x] Drift gate D19 passes (no destructive commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)