### PR TITLE
chore(backup): add pve primary vzdump + offsite gap check

### DIFF
--- a/ops/bindings/backup.inventory.yaml
+++ b/ops/bindings/backup.inventory.yaml
@@ -9,14 +9,47 @@ defaults:
   stale_after_hours: 26
 
 targets:
-  # NOTE: vzdump files not yet synced to NAS (see ronny-ops BACKUP_GOVERNANCE.md)
-  - name: vm-200-docker-host
-    enabled: false
+  # =============================================================================
+  # VM BACKUPS - PRIMARY (pve R730xd) - daily vzdump, 26h threshold
+  # =============================================================================
+  - name: vm-200-docker-host-primary
+    enabled: true
+    kind: file_glob
+    host: pve
+    base_path: "/tank/backups/vzdump/dump"
+    glob: "vzdump-qemu-200-*.vma.zst"
+    stale_after_hours: 26
+    classification: critical
+
+  - name: vm-202-primary
+    enabled: true
+    kind: file_glob
+    host: pve
+    base_path: "/tank/backups/vzdump/dump"
+    glob: "vzdump-qemu-202-*.vma.zst"
+    stale_after_hours: 26
+    classification: critical
+
+  - name: vm-203-primary
+    enabled: true
+    kind: file_glob
+    host: pve
+    base_path: "/tank/backups/vzdump/dump"
+    glob: "vzdump-qemu-203-*.vma.zst"
+    stale_after_hours: 26
+    classification: important
+
+  # =============================================================================
+  # VM BACKUPS - OFFSITE (NAS) - weekly sync, 192h threshold
+  # NOTE: Expected to show MISSING/no_matches until sync job is fixed.
+  # =============================================================================
+  - name: vm-200-docker-host-offsite
+    enabled: true
     kind: file_glob
     host: nas
     base_path: "/volume1/backups/proxmox/vzdump"
     glob: "vzdump-qemu-200-*.vma.zst"
-    stale_after_hours: 26
+    stale_after_hours: 192
     classification: critical
 
   # NOTE: path doesn't exist yet on NAS


### PR DESCRIPTION
## Summary

- Add pve primary vzdump targets for VM 200/202/203 (daily, 26h threshold)
- Enable NAS offsite target for VM 200 (weekly, 192h threshold)
- Offsite intentionally surfaces broken sync job as MISSING/no_matches

## Current State

| Target | Host | Status | Reason |
|--------|------|--------|--------|
| vm-200-docker-host-primary | pve | OK | 9.3h old |
| vm-202-primary | pve | OK | 8.9h old |
| vm-203-primary | pve | OK | 8.9h old |
| vm-200-docker-host-offsite | nas | MISSING | no_matches |
| app-vaultwarden | nas | STALE | 63h old |
| app-home-assistant | nas | STALE | 542h old |

**Summary: 6 targets | 3 ok | 3 degraded**

## What This Proves

- **Primary vzdump backups (pve)**: Working - daily backups are fresh
- **Offsite sync (nas)**: Broken - weekly folder exists but no files synced
- **App backups (nas)**: Jobs not running - need operational attention

## Test Plan

- [x] `./bin/ops cap run spine.verify` - D1-D19 PASS
- [x] `./bin/ops cap run backup.status` - 6 targets, expected results
- [x] Primary targets show OK
- [x] Offsite target shows MISSING (intentional - surfaces broken sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)