### PR TITLE
feat(secrets): SSOT inventory binding + local status capability

### DIFF
--- a/ops/bindings/secrets.inventory.yaml
+++ b/ops/bindings/secrets.inventory.yaml
@@ -1,0 +1,90 @@
+# Secrets Inventory - SSOT parity binding
+# Seeded from: ronny-ops/infrastructure/data/secrets_inventory.json
+# Purpose: Machine-readable project catalog for spine verification
+# NOTE: IDs and names are NOT secrets. No values stored here.
+
+version: 1
+
+source:
+  repo: ronny-ops
+  path: infrastructure/data/secrets_inventory.json
+  commit: 1ea9dfa91f4cf5afbd56a1a946f0a733d3bd785c
+  last_synced: "2026-02-03"
+
+infisical:
+  api_url: "https://secrets.ronny.works"
+  host: "docker-host"
+  environment: "prod"
+
+# Project catalog - lifecycle is informational (risk flag), not assertion
+projects:
+  - name: infrastructure
+    id: "01ddd93a-e0f8-4c7c-ad9f-903d76ef94d9"
+    lifecycle: active
+    notes: "Spine-bound. Cloudflare, GitHub, Azure, NAS, system infrastructure"
+
+  - name: mint-os-api
+    id: "6c67b03e-ed17-4154-9a94-59837738e432"
+    lifecycle: overloaded
+    notes: "Dashboard API, vendors, payments. Proposed rename to 'mint-os'"
+
+  - name: mint-os-vault
+    id: "66d149d6-f610-4ec3-a400-3ff42ea1aa75"
+    lifecycle: overlaps
+    notes: "Overlaps with mint-os-api; consolidation candidate"
+
+  - name: mint-os-portal
+    id: "758e5db3-8d00-4ccf-8d91-aeaad0d6ed37"
+    lifecycle: delete_candidate
+    notes: "Empty project"
+
+  - name: n8n
+    id: "4b9dfc6d-13e8-43c8-bd84-9beb64eb8e16"
+    lifecycle: clean
+    notes: "Automation workflows"
+
+  - name: finance-stack
+    id: "4c34714d-6d85-4aa6-b8df-5a9505f3bcef"
+    lifecycle: clean
+    notes: "Firefly III, financial management"
+
+  - name: media-stack
+    id: "3807f1c4-e354-4aaf-a16f-8567d7f78a7e"
+    lifecycle: clean
+    notes: "Jellyfin, *arr apps, media management"
+
+  - name: immich
+    id: "4bf7f25e-596b-4293-9d2a-c2c7c2d0df42"
+    lifecycle: clean_but_duped
+    notes: "Keys duplicated in infrastructure; remove dupes from infra"
+
+  - name: home-assistant
+    id: "5df75515-7259-4c14-98b8-5adda379aade"
+    lifecycle: clean
+    notes: "Smart home control"
+
+# Known issues from SSOT - informational flags, not runtime assertions
+known_issues:
+  - id: spof-infisical-on-docker-host
+    severity: critical
+    description: "Infisical runs on docker-host (VM 200) which is a single point of failure"
+
+  - id: no-offline-bootstrap
+    severity: critical
+    description: "No offline backup of bootstrap credentials exists"
+
+  - id: infisical-backup-untested
+    severity: high
+    description: "Weekly GPG backup exists but restore procedure never tested"
+
+  - id: immich-keys-duplicated
+    severity: medium
+    description: "IMMICH_* keys exist in both 'immich' and 'infrastructure' projects"
+
+  - id: mint-os-api-overloaded
+    severity: medium
+    description: "mint-os-api has 55 keys spanning multiple concerns"
+
+  - id: infrastructure-overloaded
+    severity: medium
+    description: "infrastructure has 48 keys including AI keys and duplicates"

--- a/ops/capabilities.yaml
+++ b/ops/capabilities.yaml
@@ -151,6 +151,14 @@ capabilities:
     approval: auto
     outputs: ["stdout"]
 
+  secrets.inventory.status:
+    description: "Read-only SSOT inventory (project names + counts). No network, no secrets values."
+    command: "./ops/plugins/secrets/bin/secrets-inventory-status"
+    cwd: "$SPINE_REPO"
+    safety: read-only
+    approval: auto
+    outputs: ["stdout"]
+
   # ─────────────────────────────────────────────────────────────────────────
   # FUTURE: MUTATING (require manual approval)
   # ─────────────────────────────────────────────────────────────────────────

--- a/ops/plugins/secrets/bin/secrets-inventory-status
+++ b/ops/plugins/secrets/bin/secrets-inventory-status
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# secrets.inventory.status - Local-only inventory read (no network, no secrets)
+# Purpose: Report what the SSOT inventory says
+# Reason codes: missing_file, invalid_schema, empty_projects, ok
+
+SPINE_REPO="${SPINE_REPO:-$HOME/Code/agentic-spine}"
+INVENTORY="$SPINE_REPO/ops/bindings/secrets.inventory.yaml"
+
+echo "secrets.inventory.status"
+echo "binding: $INVENTORY"
+echo
+
+# Precondition: yq
+command -v yq >/dev/null 2>&1 || { echo "STOP: missing dependency: yq" >&2; exit 2; }
+
+# Check file exists
+if [[ ! -f "$INVENTORY" ]]; then
+  echo "status: STOP"
+  echo "reason: missing_file"
+  echo "fix: create ops/bindings/secrets.inventory.yaml from ronny-ops SSOT"
+  exit 2
+fi
+
+# Validate schema version
+VERSION="$(yq -r '.version // "missing"' "$INVENTORY")"
+if [[ "$VERSION" == "missing" || "$VERSION" == "null" ]]; then
+  echo "status: STOP"
+  echo "reason: invalid_schema"
+  echo "fix: add 'version: 1' to secrets.inventory.yaml"
+  exit 2
+fi
+
+# Count projects
+PROJECT_COUNT="$(yq -r '.projects | length' "$INVENTORY")"
+if [[ "$PROJECT_COUNT" -eq 0 ]]; then
+  echo "status: STOP"
+  echo "reason: empty_projects"
+  echo "fix: add projects[] to secrets.inventory.yaml"
+  exit 2
+fi
+
+# Extract metadata
+SOURCE_REPO="$(yq -r '.source.repo // "unknown"' "$INVENTORY")"
+SOURCE_PATH="$(yq -r '.source.path // "unknown"' "$INVENTORY")"
+SOURCE_COMMIT="$(yq -r '.source.commit // "unknown"' "$INVENTORY" | cut -c1-8)"
+LAST_SYNCED="$(yq -r '.source.last_synced // "unknown"' "$INVENTORY")"
+INFISICAL_URL="$(yq -r '.infisical.api_url // "unset"' "$INVENTORY")"
+INFISICAL_ENV="$(yq -r '.infisical.environment // "unset"' "$INVENTORY")"
+
+# Count by lifecycle
+ACTIVE_COUNT="$(yq -r '[.projects[] | select(.lifecycle == "active")] | length' "$INVENTORY")"
+CLEAN_COUNT="$(yq -r '[.projects[] | select(.lifecycle == "clean")] | length' "$INVENTORY")"
+ISSUE_COUNT="$(yq -r '[.projects[] | select(.lifecycle != "active" and .lifecycle != "clean")] | length' "$INVENTORY")"
+KNOWN_ISSUES="$(yq -r '.known_issues | length' "$INVENTORY")"
+CRITICAL_ISSUES="$(yq -r '[.known_issues[] | select(.severity == "critical")] | length' "$INVENTORY")"
+
+echo "source:"
+echo "  repo: $SOURCE_REPO"
+echo "  path: $SOURCE_PATH"
+echo "  commit: $SOURCE_COMMIT"
+echo "  last_synced: $LAST_SYNCED"
+echo
+echo "infisical:"
+echo "  api_url: $INFISICAL_URL"
+echo "  environment: $INFISICAL_ENV"
+echo
+echo "projects:"
+echo "  total: $PROJECT_COUNT"
+echo "  active: $ACTIVE_COUNT"
+echo "  clean: $CLEAN_COUNT"
+echo "  needs_attention: $ISSUE_COUNT"
+echo
+echo "known_issues:"
+echo "  total: $KNOWN_ISSUES"
+echo "  critical: $CRITICAL_ISSUES"
+echo
+
+# List projects (names only, safe)
+echo "project_names:"
+yq -r '.projects[].name' "$INVENTORY" | while read -r name; do
+  lifecycle="$(yq -r ".projects[] | select(.name == \"$name\") | .lifecycle" "$INVENTORY")"
+  printf "  - %-20s (%s)\n" "$name" "$lifecycle"
+done
+
+echo
+echo "status: OK"
+echo "reason: ok"
+exit 0


### PR DESCRIPTION
## Summary
- Seeds `ops/bindings/secrets.inventory.yaml` from ronny-ops SSOT (`infrastructure/data/secrets_inventory.json`)
- Adds `secrets.inventory.status` capability (local-only, no network, no auth required)
- Reports project counts, lifecycle breakdown, known issues

## What's in the binding
- 9 Infisical projects with lifecycle status (active/clean/overloaded/etc)
- 6 known issues (2 critical: SPOF, no-offline-bootstrap)
- No secret values - only IDs + names

## Capability output
```
projects:
  total: 9
  active: 1
  clean: 4
  needs_attention: 4

known_issues:
  total: 6
  critical: 2
```

## Test plan
- [x] `./bin/ops cap run secrets.inventory.status` returns OK
- [x] `./bin/ops cap run spine.verify` passes all drift gates
- [ ] Merge and tag

## Next
- PR for `secrets.projects.status` upgrade (live parity check)
- D20 drift gate after stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)