### PR TITLE
feat(secrets): live parity check for secrets.projects.status

### DIFF
--- a/ops/bindings/secrets.inventory.yaml
+++ b/ops/bindings/secrets.inventory.yaml
@@ -63,6 +63,11 @@ projects:
     lifecycle: clean
     notes: "Smart home control"
 
+  - name: ai-services
+    id: "2a2e4c56-6f75-460e-8db2-c426ceb4bddf"
+    lifecycle: clean
+    notes: "AI API keys (ANTHROPIC, OPENAI). Created 2026-01-28 per proposed restructure"
+
 # Known issues from SSOT - informational flags, not runtime assertions
 known_issues:
   - id: spof-infisical-on-docker-host

--- a/ops/capabilities.yaml
+++ b/ops/capabilities.yaml
@@ -144,11 +144,14 @@ capabilities:
     outputs: ["stdout"]
 
   secrets.projects.status:
-    description: "Show spine binding + projects catalog excerpt; STOP (exit 2) if bound project not ACTIVE per SSOT map."
+    description: "Compare SSOT inventory vs live Infisical projects. Reports parity deltas (names only, no secrets)."
     command: "./ops/plugins/secrets/bin/secrets-projects-status"
     cwd: "$SPINE_REPO"
     safety: read-only
     approval: auto
+    requires:
+      - secrets.binding
+      - secrets.auth.status
     outputs: ["stdout"]
 
   secrets.inventory.status:

--- a/ops/plugins/secrets/bin/secrets-projects-status
+++ b/ops/plugins/secrets/bin/secrets-projects-status
@@ -1,64 +1,179 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# If SPINE_REPO env var is set (by capability runner), use it; otherwise compute
-if [ -n "${SPINE_REPO:-}" ]; then
-  SPINE_ROOT="$SPINE_REPO"
-else
-  # Fallback: compute from script location
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  SPINE_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# secrets.projects.status - Compare SSOT inventory vs live Infisical projects
+# Requires: secrets.binding, secrets.auth.status
+# Output: counts + deltas (names only, no IDs, no secrets)
+
+SPINE_REPO="${SPINE_REPO:-$HOME/Code/agentic-spine}"
+INVENTORY="$SPINE_REPO/ops/bindings/secrets.inventory.yaml"
+BINDING="$SPINE_REPO/ops/bindings/secrets.binding.yaml"
+
+# Source credentials if available
+CREDENTIALS_FILE="${HOME}/.config/infisical/credentials"
+if [[ -f "$CREDENTIALS_FILE" ]]; then
+  source "$CREDENTIALS_FILE"
 fi
 
-BINDING="$SPINE_ROOT/ops/bindings/secrets.binding.yaml"
-MAP="$SPINE_ROOT/docs/core/INFISICAL_PROJECTS.md"
-
-echo "════════════════════════════════════════"
-echo "CAPABILITY: secrets.projects.status"
-echo "════════════════════════════════════════"
+echo "secrets.projects.status"
 echo
 
-# Preconditions: files exist
-test -f "$BINDING" || { echo "STOP: missing binding file: $BINDING"; exit 2; }
-test -f "$MAP" || { echo "STOP: missing projects map: $MAP"; exit 2; }
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECONDITIONS
+# ─────────────────────────────────────────────────────────────────────────────
 
-# Pull project id/name from binding (extract UUID from quoted YAML value).
-BOUND_ID="$(grep 'project:' "$BINDING" | head -1 | sed -E 's/.*"([a-f0-9-]{36})".*/\1/' || true)"
-BOUND_ENV="$(grep 'environment:' "$BINDING" | head -1 | sed -E 's/.*:[[:space:]]+"?([a-zA-Z0-9_]+)"?.*/\1/' || true)"
+# Dependencies
+command -v yq >/dev/null 2>&1 || { echo "status: STOP"; echo "reason: missing_dep_yq"; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "status: STOP"; echo "reason: missing_dep_jq"; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo "status: STOP"; echo "reason: missing_dep_curl"; exit 2; }
 
-if test -z "${BOUND_ID:-}"; then
-  echo "STOP: could not read project from binding: $BINDING"
+# Inventory file
+if [[ ! -f "$INVENTORY" ]]; then
+  echo "status: STOP"
+  echo "reason: missing_inventory"
+  echo "fix: run secrets.inventory.status to verify inventory exists"
   exit 2
 fi
-if test -z "${BOUND_ENV:-}"; then
-  BOUND_ENV="prod"
+
+# Auth check (names only, no values)
+INFISICAL_API_URL="${INFISICAL_API_URL:-$(yq -r '.infisical.api_url // "https://secrets.ronny.works"' "$INVENTORY")}"
+CLIENT_ID="${INFISICAL_UNIVERSAL_AUTH_CLIENT_ID:-}"
+CLIENT_SECRET="${INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET:-}"
+
+if [[ -z "$CLIENT_SECRET" ]]; then
+  echo "status: STOP"
+  echo "reason: auth_missing"
+  echo "fix: source ~/.config/infisical/credentials or run secrets.auth.load"
+  exit 2
 fi
 
-echo "Binding:"
-echo "  project_id: $BOUND_ID"
-echo "  environment: $BOUND_ENV"
+# ─────────────────────────────────────────────────────────────────────────────
+# READ EXPECTED PROJECTS FROM INVENTORY
+# ─────────────────────────────────────────────────────────────────────────────
+
+EXPECTED_NAMES="$(yq -r '.projects[].name' "$INVENTORY" | sort)"
+EXPECTED_COUNT="$(echo "$EXPECTED_NAMES" | wc -l | tr -d ' ')"
+
+echo "inventory:"
+echo "  source: $INVENTORY"
+echo "  projects_expected: $EXPECTED_COUNT"
 echo
 
-# Extract the catalog table and show it (small, deterministic).
-echo "Project catalog (excerpt):"
-awk '
-  BEGIN {in_table=0}
-  /^\|[[:space:]]*lifecycle[[:space:]]*\|/ {in_table=1}
-  in_table {print}
-  in_table && /^[[:space:]]*$/ {exit}
-' "$MAP" | head -50
+# ─────────────────────────────────────────────────────────────────────────────
+# AUTHENTICATE (no secrets printed)
+# ─────────────────────────────────────────────────────────────────────────────
 
+AUTH_RESPONSE="$(curl -s --max-time 10 -X POST "${INFISICAL_API_URL}/api/v1/auth/universal-auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"clientId\": \"${CLIENT_ID}\", \"clientSecret\": \"${CLIENT_SECRET}\"}" 2>/dev/null || echo '{"error":"api_unreachable"}')"
+
+ACCESS_TOKEN="$(echo "$AUTH_RESPONSE" | jq -r '.accessToken // empty')"
+
+if [[ -z "$ACCESS_TOKEN" ]]; then
+  ERROR_MSG="$(echo "$AUTH_RESPONSE" | jq -r '.message // .error // "unknown"')"
+  echo "status: STOP"
+  echo "reason: api_auth_failed"
+  echo "error: $ERROR_MSG"
+  exit 2
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FETCH LIVE PROJECTS (names only)
+# ─────────────────────────────────────────────────────────────────────────────
+
+LIVE_RESPONSE="$(curl -s --max-time 10 -X GET "${INFISICAL_API_URL}/api/v1/workspace" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" 2>/dev/null || echo '{"error":"api_unreachable"}')"
+
+if echo "$LIVE_RESPONSE" | jq -e '.workspaces' >/dev/null 2>&1; then
+  LIVE_NAMES="$(echo "$LIVE_RESPONSE" | jq -r '.workspaces[].name' | sort)"
+  LIVE_COUNT="$(echo "$LIVE_NAMES" | wc -l | tr -d ' ')"
+else
+  echo "status: STOP"
+  echo "reason: api_error"
+  echo "error: $(echo "$LIVE_RESPONSE" | jq -r '.message // .error // "invalid_json"')"
+  exit 2
+fi
+
+echo "live:"
+echo "  api_url: $INFISICAL_API_URL"
+echo "  projects_found: $LIVE_COUNT"
 echo
 
-# Enforce: bound project must be ACTIVE per SSOT map table.
-# The ACTIVE row for infrastructure contains: | **ACTIVE** | **infrastructure** | `01ddd93a...` |
-if grep -q "| \*\*ACTIVE\*\* |.*\`$BOUND_ID\`" "$MAP" 2>/dev/null || \
-   grep -q "| ACTIVE |.*\`$BOUND_ID\`" "$MAP" 2>/dev/null || \
-   grep -q "|.*ACTIVE.*|$BOUND_ID|" "$MAP" 2>/dev/null; then
-  echo "OK: bound project ($BOUND_ID) is ACTIVE in docs/core/INFISICAL_PROJECTS.md"
+# ─────────────────────────────────────────────────────────────────────────────
+# COMPARE: EXPECTED vs LIVE
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Projects in inventory but not live
+MISSING="$(comm -23 <(echo "$EXPECTED_NAMES") <(echo "$LIVE_NAMES") | grep -v '^$' || true)"
+if [[ -z "$MISSING" ]]; then
+  MISSING_COUNT=0
+else
+  MISSING_COUNT="$(echo "$MISSING" | wc -l | tr -d ' ')"
+fi
+
+# Projects live but not in inventory
+EXTRA="$(comm -13 <(echo "$EXPECTED_NAMES") <(echo "$LIVE_NAMES") | grep -v '^$' || true)"
+if [[ -z "$EXTRA" ]]; then
+  EXTRA_COUNT=0
+else
+  EXTRA_COUNT="$(echo "$EXTRA" | wc -l | tr -d ' ')"
+fi
+
+echo "parity:"
+echo "  expected: $EXPECTED_COUNT"
+echo "  found: $LIVE_COUNT"
+echo "  missing: $MISSING_COUNT"
+echo "  extra: $EXTRA_COUNT"
+
+if [[ "$MISSING_COUNT" -gt 0 ]]; then
+  echo
+  echo "missing_projects:"
+  echo "$MISSING" | while read -r name; do
+    [[ -n "$name" ]] && echo "  - $name"
+  done
+fi
+
+if [[ "$EXTRA_COUNT" -gt 0 ]]; then
+  echo
+  echo "extra_projects:"
+  echo "$EXTRA" | while read -r name; do
+    [[ -n "$name" ]] && echo "  - $name"
+  done
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# KNOWN ISSUES SUMMARY (from inventory)
+# ─────────────────────────────────────────────────────────────────────────────
+
+CRITICAL_COUNT="$(yq -r '[.known_issues[] | select(.severity == "critical")] | length' "$INVENTORY")"
+HIGH_COUNT="$(yq -r '[.known_issues[] | select(.severity == "high")] | length' "$INVENTORY")"
+MEDIUM_COUNT="$(yq -r '[.known_issues[] | select(.severity == "medium")] | length' "$INVENTORY")"
+
+echo
+echo "known_issues:"
+echo "  critical: $CRITICAL_COUNT"
+echo "  high: $HIGH_COUNT"
+echo "  medium: $MEDIUM_COUNT"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STATUS
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo
+if [[ "$MISSING_COUNT" -gt 0 ]]; then
+  echo "status: DEGRADED"
+  echo "reason: drift_missing"
+  exit 1
+elif [[ "$EXTRA_COUNT" -gt 0 ]]; then
+  echo "status: DEGRADED"
+  echo "reason: drift_extra"
+  exit 1
+elif [[ "$CRITICAL_COUNT" -gt 0 ]]; then
+  echo "status: OK"
+  echo "reason: ok_with_critical_issues"
+  exit 0
+else
+  echo "status: OK"
+  echo "reason: ok"
   exit 0
 fi
-
-echo "STOP: bound project ($BOUND_ID) is NOT marked ACTIVE in docs/core/INFISICAL_PROJECTS.md"
-echo "Fix: update the lifecycle table or change ops/bindings/secrets.binding.yaml"
-exit 2


### PR DESCRIPTION
## Summary
- Upgrades `secrets.projects.status` to compare SSOT inventory vs live Infisical
- Uses `/api/v1/workspace` endpoint for project listing
- Reports parity deltas (names only, no IDs, no secrets)
- Adds `ai-services` to inventory (detected as drift_extra, now synced)

## Output contract (safe)
```
parity:
  expected: 10
  found: 10
  missing: 0
  extra: 0

known_issues:
  critical: 2
  high: 1
  medium: 3

status: OK
reason: ok_with_critical_issues
```

## Reason codes
- `auth_missing` - No credentials
- `api_auth_failed` - Auth failed
- `api_error` - API unreachable/invalid response
- `drift_missing` - Projects in inventory not in live
- `drift_extra` - Projects in live not in inventory
- `ok` / `ok_with_critical_issues` - Parity achieved

## Test plan
- [x] Without auth → `status: STOP, reason: auth_missing`
- [x] With auth → `status: OK, reason: ok_with_critical_issues`
- [x] `spine.verify` passes all drift gates
- [ ] Merge and tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)