### PR TITLE
feat(spine): repair coverage layers (nodes/stacks/services) + D22/D23 locks

### DIFF
--- a/ops/bindings/docker.compose.targets.yaml
+++ b/ops/bindings/docker.compose.targets.yaml
@@ -20,12 +20,12 @@ targets:
         path: ~/stacks/mail-archiver
       - name: mcpjungle
         path: ~/stacks/mcpjungle
-      - name: mint-os-data
-        path: ~/stacks/mint-os-data
       - name: pihole
         path: ~/stacks/pihole
       - name: secrets
         path: ~/stacks/secrets
+      - name: storage
+        path: ~/ronny-ops/infrastructure/storage
 
   media-stack:
     ssh_target: media-stack

--- a/ops/bindings/services.health.yaml
+++ b/ops/bindings/services.health.yaml
@@ -1,0 +1,42 @@
+# Services Health Binding
+# Non-secret. Spine-native. Read-only HTTP probes.
+#
+# Source SSOT: ronny-ops/infrastructure/SERVICE_REGISTRY.md
+# Each endpoint is a known service health URL (no auth required).
+
+version: 1
+
+defaults:
+  connect_timeout_sec: 5
+  max_time_sec: 10
+
+endpoints:
+  - id: mint-os-api
+    host: docker-host
+    url: "http://100.92.156.118:3335/health"
+    expect: 200
+    notes: "Mint OS Dashboard API"
+
+  - id: minio
+    host: docker-host
+    url: "http://100.92.156.118:9000/minio/health/live"
+    expect: 200
+    notes: "MinIO storage"
+
+  - id: n8n
+    host: automation-stack
+    url: "http://100.98.70.70:5678/healthz"
+    expect: 200
+    notes: "n8n workflow automation"
+
+  - id: anythingllm
+    host: macbook
+    url: "http://localhost:3002/api/ping"
+    expect: 200
+    notes: "AnythingLLM RAG"
+
+  - id: qdrant
+    host: macbook
+    url: "http://localhost:6333/collections"
+    expect: 200
+    notes: "Qdrant vector DB"

--- a/ops/bindings/ssh.targets.yaml
+++ b/ops/bindings/ssh.targets.yaml
@@ -27,10 +27,10 @@ ssh:
       notes: "Proxmox VE - shop location"
       tags: ["proxmox", "hypervisor", "core"]
 
-    - id: "beelink"
+    - id: "proxmox-home"
       host: "100.103.99.62"
       user: "root"
-      notes: "Proxmox home / offsite backup"
+      notes: "Proxmox Host (Home) - Beelink Mini"
       tags: ["proxmox", "backup", "home"]
 
     - id: "nas"
@@ -70,8 +70,14 @@ ssh:
       notes: "Pi-hole DNS (home) - slow WAN link"
       tags: ["dns", "network", "home"]
 
-    - id: "immich"
+    - id: "immich-1"
       host: "100.114.101.50"
       user: "root"
-      notes: "Immich photo server"
+      notes: "Immich photo server (shop)"
       tags: ["photos", "storage"]
+
+    - id: "download-home"
+      host: "100.125.138.110"
+      user: "root"
+      notes: "*arr apps (home)"
+      tags: ["media", "home"]

--- a/ops/capabilities.yaml
+++ b/ops/capabilities.yaml
@@ -252,6 +252,14 @@ capabilities:
     approval: auto
     outputs: ["stdout"]
 
+  nodes.status:
+    description: "Node/VM reachability across Tier 1-3 estate (alias for ssh.target.status)."
+    command: "./ops/plugins/ssh/bin/ssh-target-status"
+    cwd: "$SPINE_REPO"
+    safety: read-only
+    approval: auto
+    outputs: ["stdout"]
+
   # ─────────────────────────────────────────────────────────────────────────
   # DOCKER (read-only compose status)
   # ─────────────────────────────────────────────────────────────────────────
@@ -267,6 +275,18 @@ capabilities:
   # ─────────────────────────────────────────────────────────────────────────
   # BACKUP (read-only inventory status)
   # ─────────────────────────────────────────────────────────────────────────
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # SERVICES (read-only HTTP health probes)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  services.health.status:
+    description: "Read-only HTTP health probe for declared service endpoints (no auth, no verbose)."
+    command: "./ops/plugins/services/bin/services-health-status"
+    cwd: "$SPINE_REPO"
+    safety: read-only
+    approval: auto
+    outputs: ["stdout"]
 
   backup.status:
     description: "Read-only backup inventory status (file_glob only, freshness + reason codes)."

--- a/ops/plugins/services/bin/services-health-status
+++ b/ops/plugins/services/bin/services-health-status
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# services-health-status - Read-only HTTP health probe for declared services
+#
+# No auth headers printed. No verbose curl. No mutations.
+# STOP=2 on preconditions (missing binding, yq, curl).
+#
+# Usage:
+#   services-health-status           # check all endpoints
+#   services-health-status <id>      # check specific endpoint
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPINE_ROOT="${SPINE_ROOT:-$(cd "$SCRIPT_DIR/../../../.." && pwd)}"
+BINDING="$SPINE_ROOT/ops/bindings/services.health.yaml"
+
+stop(){ echo "STOP (2): $*" >&2; exit 2; }
+
+command -v yq >/dev/null 2>&1 || stop "missing dependency: yq"
+command -v curl >/dev/null 2>&1 || stop "missing dependency: curl"
+[[ -f "$BINDING" ]] || stop "missing binding: $BINDING"
+
+FILTER="${1:-}"
+
+DEF_CONNECT="$(yq -r '.defaults.connect_timeout_sec // 5' "$BINDING")"
+DEF_MAX="$(yq -r '.defaults.max_time_sec // 10' "$BINDING")"
+
+COUNT="$(yq -r '.endpoints | length' "$BINDING" 2>/dev/null || echo 0)"
+[[ "$COUNT" -gt 0 ]] || stop "no endpoints configured in $BINDING"
+
+echo "services.health.status"
+echo "binding: $BINDING"
+echo "endpoints: $COUNT"
+echo
+printf "%-16s %-16s %-8s %-10s %s\n" "ID" "HOST" "STATUS" "TIME" "NOTE"
+
+fail=0
+checked=0
+
+for i in $(seq 0 $((COUNT-1))); do
+  id="$(yq -r ".endpoints[$i].id" "$BINDING")"
+  host="$(yq -r ".endpoints[$i].host" "$BINDING")"
+  url="$(yq -r ".endpoints[$i].url" "$BINDING")"
+  expect="$(yq -r ".endpoints[$i].expect // 200" "$BINDING")"
+
+  if [[ -n "$FILTER" && "$id" != "$FILTER" ]]; then
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  # Time the request (ms)
+  start_ms="$(python3 -c 'import time; print(int(time.time()*1000))')"
+
+  set +e
+  http_code="$(curl -fsS -o /dev/null -w "%{http_code}" \
+    --connect-timeout "$DEF_CONNECT" \
+    --max-time "$DEF_MAX" \
+    "$url" 2>/dev/null)"
+  curl_exit=$?
+  set -e
+
+  end_ms="$(python3 -c 'import time; print(int(time.time()*1000))')"
+  dur_ms=$((end_ms - start_ms))
+
+  if [[ "$curl_exit" -eq 0 && "$http_code" == "$expect" ]]; then
+    printf "%-16s %-16s %-8s %-10s %s\n" "$id" "$host" "OK" "${dur_ms}ms" ""
+  elif [[ "$curl_exit" -eq 0 ]]; then
+    printf "%-16s %-16s %-8s %-10s %s\n" "$id" "$host" "DEGRADED" "${dur_ms}ms" "http=$http_code expected=$expect"
+    fail=1
+  elif [[ "$curl_exit" -eq 28 ]]; then
+    printf "%-16s %-16s %-8s %-10s %s\n" "$id" "$host" "TIMEOUT" "${dur_ms}ms" "connect/max timeout"
+    fail=1
+  elif [[ "$curl_exit" -eq 7 ]]; then
+    printf "%-16s %-16s %-8s %-10s %s\n" "$id" "$host" "REFUSED" "${dur_ms}ms" "connection refused"
+    fail=1
+  else
+    printf "%-16s %-16s %-8s %-10s %s\n" "$id" "$host" "FAIL" "${dur_ms}ms" "curl_exit=$curl_exit"
+    fail=1
+  fi
+done
+
+echo
+
+if [[ "$checked" -eq 0 && -n "$FILTER" ]]; then
+  echo "STOP (2): endpoint '$FILTER' not found in binding"
+  exit 2
+fi
+
+if [[ "$fail" -eq 1 ]]; then
+  echo "status: FAIL (some endpoints unhealthy)"
+  exit 1
+fi
+
+echo "status: OK (all endpoints healthy)"
+exit 0

--- a/surfaces/verify/d22-nodes-drift.sh
+++ b/surfaces/verify/d22-nodes-drift.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# D22: Nodes Surface Lock
+# Ensures SSH/nodes tooling is read-only and non-leaky.
+#
+# FORBID:
+#   - ssh -v / -vv / -vvv (verbose leaks host keys/handshake)
+#   - cat ~/.ssh/* (credential reading)
+#   - printenv | env | set | (env dumping)
+#   - reboot | shutdown | rm | pct stop | qm stop (remote mutations)
+#
+# ALLOW:
+#   - ssh <target> true / uptime / hostname
+#   - pvesh get (read-only Proxmox API)
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() { echo "D22 FAIL: $*" >&2; exit 1; }
+
+# Scope: SSH plugin surface + binding
+FILES=(
+  ops/plugins/ssh/bin/ssh-*
+  ops/bindings/ssh*.yaml
+)
+
+expanded=()
+for f in "${FILES[@]}"; do
+  while IFS= read -r path; do expanded+=("$path"); done < <(ls -1 $f 2>/dev/null || true)
+done
+
+((${#expanded[@]})) || fail "no nodes surface files found to check"
+
+# 1) Forbid verbose SSH (leaks handshake/keys)
+if rg -n '\bssh\b.*\s-v\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' | grep -v 'LogLevel' >/dev/null; then
+  fail "verbose ssh (-v) detected in nodes surface"
+fi
+
+# 2) Forbid credential file reading
+if rg -n 'cat\s+.*\.ssh/' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "SSH credential file reading detected"
+fi
+
+# 3) Forbid env dumping
+if rg -n '\b(printenv|^env\s|set\s+-x)\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "env dumping detected in nodes surface"
+fi
+
+# 4) Forbid remote mutations
+if rg -n '\b(reboot|shutdown|halt|poweroff)\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "remote mutation command (reboot/shutdown) detected"
+fi
+
+if rg -n '\brm\s+-[rf]' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "destructive rm command detected in nodes surface"
+fi
+
+if rg -n '\b(pct\s+stop|qm\s+stop|pct\s+destroy|qm\s+destroy)\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "Proxmox mutation (stop/destroy) detected"
+fi
+
+# 5) Token/secret leak guardrail
+if rg -n '(echo|printf).*(TOKEN|SECRET|API_KEY|PASSWORD|PRIVATE_KEY)' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "potential secret printing detected in nodes surface"
+fi
+
+echo "D22 PASS: nodes surface drift locked"

--- a/surfaces/verify/d23-health-drift.sh
+++ b/surfaces/verify/d23-health-drift.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# D23: Services Health Surface Lock
+# Ensures health-check tooling is read-only and non-leaky.
+#
+# FORBID:
+#   - curl -v / --verbose (dumps headers including auth)
+#   - Printing Authorization/Bearer patterns
+#   - Mutating HTTP methods (POST/PUT/PATCH/DELETE)
+#   - set -x (debug tracing leaks values)
+#
+# ALLOW:
+#   - curl -fsS to known URLs only
+#   - HTTP status code capture via -w
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() { echo "D23 FAIL: $*" >&2; exit 1; }
+
+# Scope: services plugin surface + binding
+FILES=(
+  ops/plugins/services/bin/services-*
+  ops/bindings/services*.yaml
+)
+
+expanded=()
+for f in "${FILES[@]}"; do
+  while IFS= read -r path; do expanded+=("$path"); done < <(ls -1 $f 2>/dev/null || true)
+done
+
+((${#expanded[@]})) || fail "no services health surface files found to check"
+
+# 1) Forbid verbose curl (leaks response headers)
+if rg -n '\bcurl\b.*\s(-v|--verbose)\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "verbose curl detected in health surface"
+fi
+
+# 2) Forbid printing auth headers
+if rg -n '(echo|printf).*(Authorization|Bearer|X-Auth)' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "auth header printing detected in health surface"
+fi
+
+# 3) Forbid mutating HTTP methods
+if rg -n '\bcurl\b.*\s-X\s*(POST|PUT|PATCH|DELETE)\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "mutating HTTP method detected in health surface"
+fi
+
+# 4) Forbid debug tracing
+if rg -n '\bset\s+-x\b' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "debug tracing (set -x) detected in health surface"
+fi
+
+# 5) Token/secret leak guardrail
+if rg -n '(echo|printf).*(TOKEN|SECRET|API_KEY|PASSWORD)' "${expanded[@]}" 2>/dev/null | grep -v '^\s*#' >/dev/null; then
+  fail "potential secret printing detected in health surface"
+fi
+
+echo "D23 PASS: services health surface drift locked"

--- a/surfaces/verify/drift-gate.sh
+++ b/surfaces/verify/drift-gate.sh
@@ -52,7 +52,9 @@ COUPLE="$(rg -n '(\$HOME/agent|~/agent)' bin ops ops/runtime/inbox surfaces/veri
   | rg -v 'github-actions-gate.sh' \
   | rg -v 'd18-docker-compose-drift.sh' \
   | rg -v 'd19-backup-drift.sh' \
-  | rg -v 'd20-secrets-drift.sh' || true)"
+  | rg -v 'd20-secrets-drift.sh' \
+  | rg -v 'd22-nodes-drift.sh' \
+  | rg -v 'd23-health-drift.sh' || true)"
 [[ -z "$COUPLE" ]] && pass || fail "legacy coupling found"
 
 # D6: Receipts exist (latest 5 have receipt.md)
@@ -237,6 +239,30 @@ if [[ -x "$SP/surfaces/verify/d20-secrets-drift.sh" ]]; then
   fi
 else
   warn "secrets drift gate not present"
+fi
+
+# D22: Nodes surface drift gate (read-only SSH, no credentials, no mutations)
+echo -n "D22 nodes drift gate... "
+if [[ -x "$SP/surfaces/verify/d22-nodes-drift.sh" ]]; then
+  if "$SP/surfaces/verify/d22-nodes-drift.sh" >/dev/null 2>&1; then
+    pass
+  else
+    fail "d22-nodes-drift.sh failed"
+  fi
+else
+  warn "nodes drift gate not present"
+fi
+
+# D23: Services health surface drift gate (no verbose curl, no auth printing)
+echo -n "D23 health drift gate... "
+if [[ -x "$SP/surfaces/verify/d23-health-drift.sh" ]]; then
+  if "$SP/surfaces/verify/d23-health-drift.sh" >/dev/null 2>&1; then
+    pass
+  else
+    fail "d23-health-drift.sh failed"
+  fi
+else
+  warn "health drift gate not present"
 fi
 
 echo


### PR DESCRIPTION
## What
Adds missing Spine coverage layers without conflating SSOT scopes:
- **Nodes**: `nodes.status` (SSH reachability probe) + **D22** nodes surface lock
- **Services**: `services.health.status` (HTTP health probes) + **D23** health surface lock
- **Stacks**: expands compose targets to multi-host + removes non-stack data volume target

## Files
- Modified:
  - `ops/bindings/ssh.targets.yaml` (beelink→proxmox-home, immich→immich-1, add download-home)
  - `ops/bindings/docker.compose.targets.yaml` (remove mint-os-data, add storage; multi-host coverage)
  - `ops/capabilities.yaml` (register nodes.status + services.health.status)
  - `surfaces/verify/drift-gate.sh` (add D22 + D23)
- New:
  - `ops/bindings/services.health.yaml`
  - `ops/plugins/services/bin/services-health-status`
  - `surfaces/verify/d22-nodes-drift.sh`
  - `surfaces/verify/d23-health-drift.sh`

## Proof
- `spine.verify` → ✅ PASS (D1–D23)
- `docker.compose.status` → ✅ 10/10 OK (3 hosts)
- `services.health.status` → ✅ 5/5 OK
- `nodes.status` → ⚠️ 9/11 OK (expected; real infra gaps)

## Decision Receipt (Workbench follow-up)
Both targets are intended to be reachable; binding left unchanged so Spine continues to surface failures until fixed:
- **immich-1** (VM 203 on pve): SHOULD BE UP (currently stopped)
- **download-home** (LXC 103 on proxmox-home): ADD KEY (authorized_keys missing)

Expected after workbench fixes: `nodes.status` → 11/11 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)